### PR TITLE
swap `uglifyjs` for `uglify-js`

### DIFF
--- a/lib/js-size.js
+++ b/lib/js-size.js
@@ -1,6 +1,6 @@
 var gzip = require('gzip-size');
 var pb = require('pretty-bytes');
-var uglify = require('uglifyjs');
+var uglify = require('uglify-js');
 var Table = require('cli-table');
 
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "concat-stream": "^1.4.6",
     "gzip-size": "^1.0.0",
     "pretty-bytes": "^1.0.1",
-    "uglifyjs": "^2.3.6"
+    "uglify-js": "^2.4.16"
   },
   "devDependencies": {
     "browserify": "^5.11.2",


### PR DESCRIPTION
apparently `uglifyjs` was unpublished yesterday: https://www.npmjs.com/package/uglifyjs

`uglify-js` is a more popular drop-in replacement.